### PR TITLE
feat: improve Registry implementation

### DIFF
--- a/requirements/requirements.test.txt
+++ b/requirements/requirements.test.txt
@@ -1,5 +1,4 @@
 instructor>=1.7.0
-loguru>=0.7.3
 openai>=1.58.1
 pandas>=2.1.1
 pre-commit>=4.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,5 @@
 annotated-types>=0.7.0
+loguru>=0.7.3
 Pillow>=11.0.0
 pydantic>=2.5,<3
 pydantic_core>=2.23.4


### PR DESCRIPTION
## PR Description

The Registry now provides a more robust and user-friendly interface for managing schemas, with better validation and error handling.

```python
from vlmrun.hub.registry import registry
from pydantic import BaseModel

# 1. Basic Schema Access
#----------------------
# Get schemas directly using dictionary syntax
invoice = registry["document.invoice"]
receipt = registry["document.receipt"]
resume = registry["document.resume"]

# Check schema existence
if "document.invoice" in registry:
    print("Invoice schema is available")

# List all available schemas
all_schemas = registry.list_schemas()
print(f"Available schemas: {all_schemas}")

# Define custom schemas
class ProductSchema(BaseModel):
    name: str
    price: float
    sku: str
    in_stock: bool = True

# Register with domain prefix
registry.register("inventory.product", ProductSchema)

# Load schemas from custom catalogs
registry.load_schemas([
    "path/to/custom/catalog.yaml",
    "path/to/another/catalog.yaml"
])

# Print registry contents
print(registry)
# Output:
# Registry [schemas=5]
#   document.invoice :: InvoiceSchema
#   document.receipt :: ReceiptSchema
#   inventory.product :: ProductSchema
#   ...

# Get list of schemas in a specific domain
document_schemas = [s for s in registry.list_schemas() if s.startswith("document.")]
print(f"Document schemas: {document_schemas}")
```