### PR TITLE
feat: add twitter/x card schema

### DIFF
--- a/docs/CONTRIBUTING-SCHEMA.md
+++ b/docs/CONTRIBUTING-SCHEMA.md
@@ -17,7 +17,7 @@ Please refer to the [Schema Guidelines](./SCHEMA-GUIDELINES.md) for comprehensiv
 
 2. **Add Tests**: Include tests for your schema in `tests/test_schemas.py`.
 
-3. **Add to the contrib Catalog**: Add your schema to the [`vlmrun/hub/schemas/contrib/catalog.yaml`](../vlmrun/hub/schemas/contrib/catalog.yaml) file in the `schemas` section, and test it with `pytest -sv tests/test_instructor.py. --domain="<domain_name>"`.
+3. **Add to the contrib Catalog**: Add your schema to the [`vlmrun/hub/schemas/contrib/catalog.yaml`](../vlmrun/hub/schemas/contrib/catalog.yaml) file in the `schemas` section, and test it with `pytest -sv tests/test_instructor.py --domain="<domain_name>"`.
 
 4. **Submit a Pull Request**: Once your schema is complete and tested, submit a pull request with the [`schema-request`](../.github/PULL_REQUEST_TEMPLATE/schema-request.yaml) template for review. You can take a look at a previous PR for reference.
 

--- a/vlmrun/hub/schemas/contrib/catalog.yaml
+++ b/vlmrun/hub/schemas/contrib/catalog.yaml
@@ -13,6 +13,15 @@ schemas:
       supported_inputs: ["image", "video"]
       tags: ["media", "sports"]
 
+  - domain: social.twitter-card
+    schema: vlmrun.hub.schemas.contrib.social.twitter_card.TwitterCard
+    prompt: "You are a detail-oriented social media analyst. Extract all the relevant information from the tweet card as accurately as possible."
+    description: "Twitter card data extraction system that processes tweet screenshots to extract structured information including tweet content, user details, engagement metrics, and quoted tweets."
+    sample_data: "https://storage.googleapis.com/vlm-data-public-prod/hub/examples/social.twitter_card/tweet_openai.png"
+    metadata:
+      supported_inputs: ["image"]
+      tags: ["social", "media"]
+
   - domain: media.nba-game-state
     schema: vlmrun.hub.schemas.contrib.media.nba_game_state.NBAGameState
     prompt: "You are a detail-oriented NBA Game Analyst. Extract all the relevant game state information from the video feed or screenshot as accurately as possible."

--- a/vlmrun/hub/schemas/contrib/social/twitter_card.py
+++ b/vlmrun/hub/schemas/contrib/social/twitter_card.py
@@ -1,0 +1,52 @@
+from datetime import date
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class User(BaseModel):
+    """Twitter user information."""
+
+    username: str = Field(..., description="The Twitter handle of the user.")
+    display_name: str = Field(..., description="The display name of the user.")
+
+
+class Media(BaseModel):
+    """Media content attached to a tweet."""
+
+    description: Optional[str] = Field(default=None, description="A description of the media content linked.")
+    type: Optional[Literal["image", "video", "url"]] = Field(
+        default=None, description="The type of media (image, video, etc.)."
+    )
+
+
+class Tweet(BaseModel):
+    """Individual tweet information including content and engagement metrics."""
+
+    content: Optional[str] = Field(default=None, description="The text content of the tweet.")
+    created_at: Optional[date] = Field(default=None, description="The timestamp when the tweet was created.")
+    user: Optional[User] = Field(default=None, description="The user who posted the tweet.")
+    media: Optional[List[Media]] = Field(default=None, description="List of media items attached to the tweet, if any.")
+    retweet_count: Optional[int] = Field(
+        default=None, description="The approximate number of times this tweet has been retweeted."
+    )
+    like_count: Optional[int] = Field(
+        default=None, description="The approximate number of likes this tweet has received (icon is a heart)."
+    )
+    reply_count: Optional[int] = Field(
+        default=None, description="The approximate number of replies to this tweet (icon is a reply arrow)."
+    )
+    view_count: Optional[int] = Field(
+        default=None,
+        description="The approximate number of views this tweet has received (icon is a vertical bar chart).",
+    )
+    quote_count: Optional[int] = Field(
+        default=None, description="The approximate number of times this tweet has been quoted."
+    )
+
+
+class TwitterCard(BaseModel):
+    """A Twitter card containing tweet information and any quoted tweets."""
+
+    tweet: Tweet = Field(..., description="The main tweet content and metadata.")
+    quoted_tweet: Optional[Tweet] = Field(default=None, description="A tweet that is quoted by the main tweet, if any.")


### PR DESCRIPTION
# Schema: New schema for social.twitter_card

## Schema Motivation
Adding a schema for structured extraction of Twitter content, enabling comprehensive capture of tweets, user information, and engagement metrics.

Benefits:
- Standardizes Twitter content extraction
- Captures hierarchical relationships between tweets and quoted content
- Includes comprehensive engagement metrics and media attachments
- Supports social media analysis and content monitoring

## Sample
https://storage.googleapis.com/vlm-data-public-prod/hub/examples/social.twitter_card/tweet_openai.png

## Sample JSON Output
```json
{
  "tweet": {
    "content": "Most of ChatGPT, the API, and Sora have been down for a couple of hours and we're sorry for the trouble this is causing.\n\nWe've 
identified the issue and have started recovery. We hope to be back asap. status.openai.com",
    "created_at": "2024-12-27",
    "user": {
      "username": "OpenAI",
      "display_name": "OpenAI"
    },
    "media": null,
    "retweet_count": 879,
    "like_count": 841,
    "reply_count": 0,
    "view_count": 1300000,
    "quote_count": 0
  },
  "quoted_tweet": null
}
```

